### PR TITLE
Update README with npm ci note

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ Accepts JSON body with violation data and responds with a simulated success mess
 Accepts an array of transport events and returns a success message.
 
 This server is intended only for local testing and does not persist data between runs.
+
+When using GitHub Actions, ensure that `package-lock.json` is committed. The
+workflow relies on `npm ci`, which requires this lock file to install
+dependencies.


### PR DESCRIPTION
## Summary
- document that `package-lock.json` must be committed so Github Actions can run `npm ci`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841b4cad9c0832592967157899b19a3