### PR TITLE
Adapt server tests to new KAAT auth

### DIFF
--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,7 +1,15 @@
 import request from 'supertest';
-import { app } from '../src/index';
+import type { Express } from 'express';
+
+const KAAT_TOKEN = 'test-kaat-token';
+let app: Express;
 
 let token: string;
+
+beforeAll(() => {
+  process.env.KAAT_TOKEN = KAAT_TOKEN;
+  app = require('../src/index').app;
+});
 
 describe('Mock KAAT server', () => {
   it('authenticates and returns a token', async () => {
@@ -32,8 +40,13 @@ describe('Mock KAAT server', () => {
   it('creates a violation event', async () => {
     const res = await request(app)
       .post('/billing-api/v1/device-event/create')
-      .set('Authorization', `Bearer ${token}`)
-      .send({ pID: '2000' });
+      .set('Authorization', `Bearer ${KAAT_TOKEN}`)
+      .send({
+        pID: '2000',
+        pDeviceNumber: 'D-1',
+        pViolation: 1,
+        pLink: 'https://mock.example/video.mp4'
+      });
     expect(res.status).toBe(200);
     expect(res.body.status).toBe('OK');
     expect(res.body.event_id).toBe('2000');
@@ -42,7 +55,7 @@ describe('Mock KAAT server', () => {
   it('inputs all cars', async () => {
     const res = await request(app)
       .post('/car-search/v1/device-event/input-all')
-      .set('Authorization', `Bearer ${token}`)
+      .set('Authorization', `Bearer ${KAAT_TOKEN}`)
       .send([{ device_reg_number: '123' }]);
     expect(res.status).toBe(200);
     expect(res.body.status).toBe('success');


### PR DESCRIPTION
## Summary
- update server tests to set `KAAT_TOKEN` before importing the app
- use the KAAT token for KAAT endpoints and send all required fields

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68457153f7c08325bddda57cfd133dd5