### PR TITLE
Implement speed validation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -150,6 +150,7 @@ app.post(
       pID,
       pDeviceNumber,
       pViolation,
+      pActualSpeed,
       pLink,
       pPhoto,
       pPhotoPlate
@@ -158,6 +159,35 @@ app.post(
 
     if (!pID || !pDeviceNumber || pViolation == null || !pLink) {
       return res.status(400).json({ status: 'ERROR', message: 'Missing required fields' });
+    }
+
+    const speed = Math.abs(Number(pActualSpeed));
+
+    if (Number.isNaN(speed)) {
+      console.log('Event rejected: invalid speed');
+      return res.status(400).json({ status: 'REJECT', message: 'Invalid speed' });
+    }
+
+    let expectedViolation: number | null = null;
+
+    if (speed <= 65) {
+      console.log(`Event rejected: speed ${speed} below violation threshold`);
+      return res.status(400).json({ status: 'REJECT', message: 'No violation detected' });
+    } else if (speed <= 85) {
+      expectedViolation = 36;
+    } else if (speed <= 105) {
+      expectedViolation = 37;
+    } else if (speed <= 125) {
+      expectedViolation = 201;
+    } else {
+      expectedViolation = 202;
+    }
+
+    if (expectedViolation !== Number(pViolation)) {
+      console.log(
+        `Event rejected: speed ${speed} requires violation ${expectedViolation}, received ${pViolation}`
+      );
+      return res.status(400).json({ status: 'REJECT', message: 'Violation code does not match speed' });
     }
 
     res.json({

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -44,12 +44,43 @@ describe('Mock KAAT server', () => {
       .send({
         pID: '2000',
         pDeviceNumber: 'D-1',
-        pViolation: 1,
+        pViolation: 202,
+        pActualSpeed: 130,
         pLink: 'https://mock.example/video.mp4'
       });
     expect(res.status).toBe(200);
     expect(res.body.status).toBe('OK');
     expect(res.body.event_id).toBe('2000');
+  });
+
+  it('rejects mismatched violation code', async () => {
+    const res = await request(app)
+      .post('/billing-api/v1/device-event/create')
+      .set('Authorization', `Bearer ${KAAT_TOKEN}`)
+      .send({
+        pID: '3000',
+        pDeviceNumber: 'D-1',
+        pViolation: 36,
+        pActualSpeed: 90,
+        pLink: 'https://mock.example/video.mp4'
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.status).toBe('REJECT');
+  });
+
+  it('rejects when speed below threshold', async () => {
+    const res = await request(app)
+      .post('/billing-api/v1/device-event/create')
+      .set('Authorization', `Bearer ${KAAT_TOKEN}`)
+      .send({
+        pID: '4000',
+        pDeviceNumber: 'D-1',
+        pViolation: 36,
+        pActualSpeed: 60,
+        pLink: 'https://mock.example/video.mp4'
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.status).toBe('REJECT');
   });
 
   it('inputs all cars', async () => {


### PR DESCRIPTION
## Summary
- add server-side validation of speed/violation pair
- extend tests for the new validation logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845bad52f308325a51dd5bb0ef623ac