### PR TITLE
Modify auth endpoint response

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,20 @@ and any validation errors.
 ## Endpoints
 
 ### `POST /auth`
-Returns a bearer token for further requests.
+Authenticates a user and returns JSON:
+
+```
+{
+  "code": 200,
+  "message": "Successfully logged in!",
+  "data": {
+    "token": "<token>",
+    "expiresIn": 86400
+  }
+}
+```
+
+Use the returned token for subsequent requests.
 
 ### `POST /video/upload`
 Requires `Authorization: Bearer <token>` header and accepts `multipart/form-data` with fields `id`, `car_number`, `the_date`, `rule_id`, `video`, `car_photo`, `full_photo`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,14 @@ app.post('/auth', (req: Request, res: Response) => {
   }
   issuedToken = Math.random().toString(36).substring(2);
   console.log(`Authenticated user ${username}, issued token ${issuedToken}`);
-  res.json({ token: issuedToken });
+  res.json({
+    code: 200,
+    message: 'Successfully logged in!',
+    data: {
+      token: issuedToken,
+      expiresIn: 86400,
+    },
+  });
 });
 
 // 2. PLINK upload (video + photos)

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -37,8 +37,10 @@ describe('Mock KAAT server', () => {
       .post('/auth')
       .send({ username: 'user', password: 'pass' });
     expect(res.status).toBe(200);
-    expect(res.body.token).toBeDefined();
-    token = res.body.token;
+    expect(res.body.code).toBe(200);
+    expect(res.body.data.token).toBeDefined();
+    expect(res.body.data.expiresIn).toBe(86400);
+    token = res.body.data.token;
   });
 
   it('uploads video and photos', async () => {


### PR DESCRIPTION
## Summary
- return detailed JSON from `/auth` to match external service
- document updated auth response format
- adjust tests for new `/auth` structure

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a80b57bd883258239f019d60e5320