### PR TITLE
Add PLINK-style upload response

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Use the returned token for subsequent requests.
 
 ### `POST /video/upload`
 Requires `Authorization: Bearer <token>` header and accepts `multipart/form-data` with fields `id`, `car_number`, `the_date`, `rule_id`, `video`, `car_photo`, `full_photo`.
+Responds with:
+
+```json
+{ "code": 200, "data": { "guid": "<guid>", "url": "https://mock.example/<guid>" } }
+```
 
 ### `POST /billing-api/v1/device-event/create`
 Accepts JSON body with violation data and responds with a simulated success message.

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,8 +151,9 @@ app.post(
       }
     }
 
-    const url = `https://mock.example/${path.basename(video.path)}`;
-    res.json({ status: 'success', url });
+    const guid = Math.random().toString(36).substring(2, 10);
+    const url = `https://mock.example/${guid}`;
+    res.json({ code: 200, data: { guid, url } });
   }
 );
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -55,8 +55,9 @@ describe('Mock KAAT server', () => {
       .attach('car_photo', 'tests/fixtures/car.jpg')
       .attach('full_photo', 'tests/fixtures/full.jpg');
     expect(res.status).toBe(200);
-    expect(res.body.status).toBe('success');
-    expect(res.body.url).toContain('https://');
+    expect(res.body.code).toBe(200);
+    expect(res.body.data.guid).toBeDefined();
+    expect(res.body.data.url).toContain('https://');
   });
 
   it('creates a violation event', async () => {


### PR DESCRIPTION
## Summary
- update `/video/upload` route to mimic PLINK API response format
- adjust the unit test to expect new JSON structure
- document the upload response in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a82931ae4832596b847b00686a3d5